### PR TITLE
Add timelock functionality.

### DIFF
--- a/contracts/interfaces/IFlashProtocol.sol
+++ b/contracts/interfaces/IFlashProtocol.sol
@@ -2,6 +2,10 @@
 pragma solidity 0.6.12;
 
 interface IFlashProtocol {
+    enum LockedFunctions { SET_MATCH_RATIO, SET_MATCH_RECEIVER }
+
+    function TIMELOCK() external view returns (uint256);
+
     function FLASH_TOKEN() external view returns (address);
 
     function matchRatio() external view returns (uint256);
@@ -32,6 +36,12 @@ interface IFlashProtocol {
             uint256 matchedAmount,
             bytes32 id
         );
+
+    function lockFunction(LockedFunctions _lockedFunction) external;
+
+    function unlockFunction(LockedFunctions _lockedFunction) external;
+
+    function timelock(LockedFunctions _lockedFunction) external view returns (uint256);
 
     function balances(address _staker) external view returns (uint256);
 


### PR DESCRIPTION
`setMatchRatio` and `setMatchReceiver` are now timelocked for 3 days.

The flow is as follows:
- the match receiver calls `unlockFunction` for the appropriate function (i.e. `setMatchRatio` or `setMatchReceiver`)
- after 3 days the function that has been unlocked can be called


By calling `lockFunction` for the appropriate function, you are disabling the functionality forever.